### PR TITLE
Spot termination exporter - fetch rebalance recommendations

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -10,10 +10,12 @@ import (
 )
 
 type terminationCollector struct {
-	metadataEndpoint     string
-	scrapeSuccessful     *prometheus.Desc
-	terminationIndicator *prometheus.Desc
-	terminationTime      *prometheus.Desc
+	metadataEndpoint          string
+	rebalanceIndicator        *prometheus.Desc
+	rebalanceScrapeSuccessful *prometheus.Desc
+	scrapeSuccessful          *prometheus.Desc
+	terminationIndicator      *prometheus.Desc
+	terminationTime           *prometheus.Desc
 }
 
 type InstanceAction struct {
@@ -21,16 +23,24 @@ type InstanceAction struct {
 	Time   time.Time `json:"time"`
 }
 
+type InstanceEvent struct {
+	NoticeTime time.Time `json:"noticeTime"`
+}
+
 func NewTerminationCollector(me string) *terminationCollector {
 	return &terminationCollector{
-		metadataEndpoint:     me,
-		scrapeSuccessful:     prometheus.NewDesc("aws_instance_metadata_service_available", "Metadata service available", []string{"instance_id"}, nil),
-		terminationIndicator: prometheus.NewDesc("aws_instance_termination_imminent", "Instance is about to be terminated", []string{"instance_action", "instance_id"}, nil),
-		terminationTime:      prometheus.NewDesc("aws_instance_termination_in", "Instance will be terminated in", []string{"instance_id"}, nil),
+		metadataEndpoint:          me,
+		rebalanceIndicator:        prometheus.NewDesc("aws_instance_rebalance_recommended", "Instance rebalance is recommended", []string{"instance_id", "instance_type"}, nil),
+		rebalanceScrapeSuccessful: prometheus.NewDesc("aws_instance_metadata_service_events_available", "Metadata service events endpoint available", []string{"instance_id"}, nil),
+		scrapeSuccessful:          prometheus.NewDesc("aws_instance_metadata_service_available", "Metadata service available", []string{"instance_id"}, nil),
+		terminationIndicator:      prometheus.NewDesc("aws_instance_termination_imminent", "Instance is about to be terminated", []string{"instance_action", "instance_id", "instance_type"}, nil),
+		terminationTime:           prometheus.NewDesc("aws_instance_termination_in", "Instance will be terminated in", []string{"instance_id", "instance_type"}, nil),
 	}
 }
 
 func (c *terminationCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.rebalanceIndicator
+	ch <- c.rebalanceScrapeSuccessful
 	ch <- c.scrapeSuccessful
 	ch <- c.terminationIndicator
 	ch <- c.terminationTime
@@ -57,6 +67,20 @@ func (c *terminationCollector) Collect(ch chan<- prometheus.Metric) {
 	body, _ := ioutil.ReadAll(idResp.Body)
 	instanceId = string(body)
 
+	typeResp, err := client.Get(c.metadataEndpoint + "instance-type")
+	var instanceType string
+	if err != nil {
+		log.Errorf("couldn't parse instance-type from metadata: %s", err.Error())
+		return
+	}
+	if typeResp.StatusCode == 404 {
+		log.Errorf("couldn't parse instance-type from metadata: endpoint not found")
+		return
+	}
+	defer typeResp.Body.Close()
+	body, _ = ioutil.ReadAll(typeResp.Body)
+	instanceType = string(body)
+
 	resp, err := client.Get(c.metadataEndpoint + "spot/instance-action")
 	if err != nil {
 		log.Errorf("Failed to fetch data from metadata service: %s", err)
@@ -67,7 +91,7 @@ func (c *terminationCollector) Collect(ch chan<- prometheus.Metric) {
 
 		if resp.StatusCode == 404 {
 			log.Debug("instance-action endpoint not found")
-			ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 0, "", instanceId)
+			ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 0, "", instanceId, instanceType)
 			return
 		} else {
 			defer resp.Body.Close()
@@ -80,14 +104,43 @@ func (c *terminationCollector) Collect(ch chan<- prometheus.Metric) {
 			// so parse error is not fatal
 			if err != nil {
 				log.Errorf("Couldn't parse instance-action metadata: %s", err)
-				ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 0, instanceId)
+				ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 0, instanceId, instanceType)
 			} else {
 				log.Infof("instance-action endpoint available, termination time: %v", ia.Time)
-				ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 1, ia.Action, instanceId)
+				ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 1, ia.Action, instanceId, instanceType)
 				delta := ia.Time.Sub(time.Now())
 				if delta.Seconds() > 0 {
-					ch <- prometheus.MustNewConstMetric(c.terminationTime, prometheus.GaugeValue, delta.Seconds(), instanceId)
+					ch <- prometheus.MustNewConstMetric(c.terminationTime, prometheus.GaugeValue, delta.Seconds(), instanceId, instanceType)
 				}
+			}
+		}
+	}
+
+	eventResp, err := client.Get(c.metadataEndpoint + "events/recommendations/rebalance")
+	if err != nil {
+		log.Errorf("Failed to fetch events data from metadata service: %s", err)
+		ch <- prometheus.MustNewConstMetric(c.rebalanceScrapeSuccessful, prometheus.GaugeValue, 0, instanceId)
+		return
+	} else {
+		ch <- prometheus.MustNewConstMetric(c.rebalanceScrapeSuccessful, prometheus.GaugeValue, 1, instanceId)
+
+		if eventResp.StatusCode == 404 {
+			log.Debug("rebalance endpoint not found")
+			ch <- prometheus.MustNewConstMetric(c.rebalanceIndicator, prometheus.GaugeValue, 0, instanceId, instanceType)
+			return
+		} else {
+			defer eventResp.Body.Close()
+			body, _ := ioutil.ReadAll(eventResp.Body)
+
+			var ie = InstanceEvent{}
+			err := json.Unmarshal(body, &ie)
+
+			if err != nil {
+				log.Errorf("Couldn't parse rebalance recommendation event metadata: %s", err)
+				ch <- prometheus.MustNewConstMetric(c.rebalanceIndicator, prometheus.GaugeValue, 0, instanceId, instanceType)
+			} else {
+				log.Infof("rebalance recommendation event endpoint available, recommendation time: %v", ie.NoticeTime)
+				ch <- prometheus.MustNewConstMetric(c.rebalanceIndicator, prometheus.GaugeValue, 1, instanceId, instanceType)
 			}
 		}
 	}

--- a/util/test_server.go
+++ b/util/test_server.go
@@ -8,7 +8,7 @@ import (
 )
 
 // use this minimal http server to test the exporter locally
-// change constant to have metadataEndpoint = "http://localhost:9092/latest/meta-data/spot/instance-action"
+// Run the exporter with the flag --metadata-endpoint = "http://localhost:9092/latest/meta-data/"
 func main() {
 	http.HandleFunc("/latest/meta-data/spot/instance-action", func(w http.ResponseWriter, r *http.Request) {
 		terminationTime := time.Now().Add(2 * time.Minute)
@@ -18,6 +18,14 @@ func main() {
 
 	http.HandleFunc("/latest/meta-data/instance-id", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "i-0d2aab13057917887")
+	})
+	http.HandleFunc("/latest/meta-data/instance-type", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "c5.9xlarge")
+	})
+	http.HandleFunc("/latest/meta-data/events/recommendations/rebalance", func(w http.ResponseWriter, r *http.Request) {
+		noticeTime := time.Now()
+		utc, _ := time.LoadLocation("UTC")
+		fmt.Fprintf(w, "{\"noticeTime\":\"%s\"}", noticeTime.In(utc).Format(time.RFC3339))
 	})
 
 	log.Fatal(http.ListenAndServe(":9092", nil))


### PR DESCRIPTION
PR description from https://github.com/banzaicloud/spot-termination-exporter/pull/15

### What's in this PR?

* Adds instance_type label to terminationIndicator and terminationTime metrics to allow tracking of trends by instance type
* Adds monitoring for rebalance recommendation on instance metadata endpoint to add new metrics for when instances are being recommended for rebalance, includes the instance_id and instance_type labels

### Why?

Rebalance recommendations provide potentially significant advance notice of potential spot disruption before the 2-minute notice of a spot termination. Adding the exposure of this metric allows cluster operators to gain advance warning of potentially large scale spot interruptions in their clusters.

The addition of the instance_type label also allows cluster operators to understand if their spot interruptions are clustered on specific instance types, leading to data driven consideration of instance type choices.

